### PR TITLE
Modified driver scripts to allow dumping data to HDF5 for use as testsystems.

### DIFF
--- a/8proteins/analyzer.py
+++ b/8proteins/analyzer.py
@@ -27,6 +27,7 @@ increment2 = 0.4  # Temperature increment for transition zone (dynamic, needs as
 #=========================================================
 # PARAMETERS
 #=========================================================
+DUMP_DATA_HDF = False  # Set to True to dump u_kn, N_k, and s_n to an HDF file
 data_directory = os.path.join('in_mbar')
 out_directory = os.path.join('out_mbar')
 temperature_list_filename = os.path.join(data_directory, 'temperatures')
@@ -381,6 +382,11 @@ print "MBAR routines completed, Preparing Data to Compute Expectations..."
 print "."
 print "."
 print "."
+
+if DUMP_DATA_HDF:
+    print("Trying to dump data to HDF5 file for use in pymbar integration tests.")
+    pymbar.testsystems.pymbar_datasets.save(name="8proteins", u_kn=mbar.u_kn, N_k=mbar.N_k)
+    print("Done dumping HDF5.")
 
 #========================================================================
 # Prep E_kt

--- a/README.md
+++ b/README.md
@@ -47,3 +47,11 @@ and hopefully we can get the memory required down. Also, requires the
 installation of the included uncertainties package to run the
 analysis.
 
+Notes
+-----
+
+The driver scripts 8proteins/analyzer.py and gas-properties/run_mbar_all.py
+have an optional parameter DUMP_DATA_HDF at the top of each script.  By
+setting this flag to True and running, you can save a machine-readable
+version of the dataset to be used for testing and benchmarking your
+pymbar installation.

--- a/gas-properties/run_mbar_all.py
+++ b/gas-properties/run_mbar_all.py
@@ -21,6 +21,7 @@ import time
 #=============================================================================================
 # PARAMETERS
 #=============================================================================================
+DUMP_DATA_HDF = False  # Set to True to dump u_kn, N_k, and s_n to an HDF file
 correlated_data = 1  # Set "0" for uncorrelated original data and "1" to use subsampling
 nominal_Pstart = ['All'] # NPT input pressure (nominal value) - MPa
 N_CH4 = 512 # Number of CH4 molecules on the simulations
@@ -244,6 +245,12 @@ for directory in processed_data:
     else:
         print "Running MBAR..."
         mbar = pymbar.MBAR(u_kln, N_k, verbose = True, method = 'adaptive', relative_tolerance = 1.0e-10)
+
+    if DUMP_DATA_HDF:
+        print("Trying to dump data to HDF5 file for use in pymbar integration tests.")
+        pymbar.testsystems.pymbar_datasets.save(name="gas-properties", u_kn=mbar.u_kn, N_k=mbar.N_k)
+        print("Done dumping HDF5.")
+
     #=============================================================================================
     # COMPUTING OBSERVABLES
     #=============================================================================================


### PR DESCRIPTION
So this is a bit of a hack, but it's the best way can do given that none of us has the time to rewrite these driver scripts.  The idea here is that one can set `DUMP_DATA_HDF = True` and then run the driver script, which then saves the dataset in a format that can be used by `pymbar` for integration / regression tests.
